### PR TITLE
fix #17 🔧: remove defer attribute injection script configuration

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,7 @@ module.exports = {
   },
   plugins: [
     new HtmlWebpackPlugin({
+      inject: false,
       template: path.resolve(__dirname, './index.html'),
     }),
   ],


### PR DESCRIPTION
It is supposed to load concurrently and execute it once the HTML file is
loaded on the browser.

In contrast, script attribute 'defer' do not execute Javascript
after loading HTML.

See Also:
- https://github.com/jantimon/html-webpack-plugin#options