### PR TITLE
UIUX 💄: adjust date layout

### DIFF
--- a/src/components/Dates.jsx
+++ b/src/components/Dates.jsx
@@ -9,18 +9,19 @@ const WeekList = styled.ul({
 
 const WeekItem = styled.li({
   width: '100%',
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'center',
 
-  '$ header': {
+  overflow: 'hidden',
+
+  '& header': {
     padding: '0.2rem',
+    textAlign: 'center',
   },
 });
 
 const TaskWrapper = styled.div({
   display: 'flex',
   flexDirection: 'column',
+  padding: '0.2rem',
 });
 
 const Task = styled.div({


### PR DESCRIPTION
- align header text center
- hide contents out of day section
- give padding to create the gap between dates

![image](https://user-images.githubusercontent.com/77006427/118921163-a58fb100-b972-11eb-873c-31f9473586b1.png)
