### PR TITLE
fix 🐛: assign unique id on each task

### DIFF
--- a/src/components/Tasks.jsx
+++ b/src/components/Tasks.jsx
@@ -23,9 +23,9 @@ export default function Tasks({ tasks }) {
     <>
       {tasks.length > 0 && (
         <TaskWrapper>
-          {tasks.map((task) => (
-            <Task key={new Date()}>
-              <p>{task}</p>
+          {tasks.map(({ id, description }) => (
+            <Task key={id}>
+              <p>{description}</p>
             </Task>
           ))}
         </TaskWrapper>

--- a/src/components/tasks.test.jsx
+++ b/src/components/tasks.test.jsx
@@ -5,7 +5,16 @@ import { render, screen } from '@testing-library/react';
 import Tasks from './Tasks';
 
 describe('Tasks', () => {
-  const tasks = ['timeblocks inteview', 'Fabuolous'];
+  const tasks = [
+    {
+      id: 1,
+      description: 'timeblocks inteview',
+    },
+    {
+      id: 2,
+      description: 'Fabuolous',
+    },
+  ];
 
   it('renders tasks', () => {
     render(<Tasks tasks={tasks} />);

--- a/src/fixtures/dates.js
+++ b/src/fixtures/dates.js
@@ -76,7 +76,7 @@ export default [
       id: 23, date: '5/17/2021', day: 'Monday', tasks: [],
     },
     {
-      id: 24, date: '5/18/2021', day: 'Tuesday', tasks: ['timeblocks inteview'],
+      id: 24, date: '5/18/2021', day: 'Tuesday', tasks: [{ id: 1, description: 'timeblocks inteview' }],
     },
     {
       id: 25, date: '5/19/2021', day: 'Wednesday', tasks: [],

--- a/src/redux/appSlice.js
+++ b/src/redux/appSlice.js
@@ -6,6 +6,7 @@ import { convertTo2DArray } from '../utils/utils';
 const { actions, reducer } = createSlice({
   name: 'applications',
   initialState: {
+    id: 1,
     currentDate: {
       Month: undefined,
       Year: undefined,
@@ -47,14 +48,25 @@ const { actions, reducer } = createSlice({
     setTasks(state, { payload: task }) {
       const calendarDate = convertTo2DArray(state.calendarDate.flat().reduce((accu, curr) => {
         if (curr.date === state.clickedDate) {
-          return [...accu, { ...curr, tasks: [...curr.tasks, task] }];
+          return [
+            ...accu, {
+              ...curr,
+              tasks: [
+                ...curr.tasks,
+                {
+                  id: state.id,
+                  description: task,
+                }],
+            }];
         }
+
         return [...accu, curr];
       }, []), 7);
 
       return {
         ...state,
         calendarDate,
+        id: state.id + 1,
       };
     },
   },

--- a/src/redux/appSlice.test.js
+++ b/src/redux/appSlice.test.js
@@ -62,6 +62,7 @@ describe('setClickedDate', () => {
 describe('setTasks', () => {
   it('sets tasks into clicked date', () => {
     const initialState = {
+      id: 1,
       currentDate: {
         month: 4,
         year: 2021,
@@ -77,5 +78,7 @@ describe('setTasks', () => {
       .find(equal('date', initialState.clickedDate));
 
     expect(clickedDate.tasks).toHaveLength(1);
+
+    expect(clickedDate.tasks[0].id).toBe(1);
   });
 });


### PR DESCRIPTION
Set date object as a key in component led to volatile component behavior.
Generating new Date() rendering component is not fully unique ids.

See Also:
- https://reactjs.org/docs/lists-and-keys.html
- https://reactjs.org/docs/reconciliation.html
- https://blog.logrocket.com/unfavorable-react-keys-unpredictable-behavior/