### PR TITLE
fix 🐛: importing bundle.js script twice

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,5 @@
     </head>
     <body>
         <div id="app"></div>
-        <script src="/main.js"></script>
     </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,6 @@ module.exports = {
   },
   plugins: [
     new HtmlWebpackPlugin({
-      inject: false,
       template: path.resolve(__dirname, './index.html'),
     }),
   ],


### PR DESCRIPTION
Importing the script tag twice caused the side effect to break REACT.