### PR TITLE
test ✅: remove dependency of currentDate relying on up-to-date

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -4,8 +4,6 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { render, screen } from '@testing-library/react';
 
-import { getCurrnetDate } from './utils';
-
 import { WEEKDAY } from './fixtures';
 
 import App from './App';
@@ -13,16 +11,18 @@ import App from './App';
 describe('App', () => {
   const dispatch = jest.fn();
 
+  const currentDate = {
+    month: '5',
+    year: '2021',
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
 
     useDispatch.mockImplementation(() => dispatch);
 
     useSelector.mockImplementation((selector) => selector({
-      currentDate: {
-        month: '5',
-        year: '2021',
-      },
+      currentDate,
       calendarDate: [],
     }));
   });
@@ -36,7 +36,7 @@ describe('App', () => {
   it('renders current Month and Year', () => {
     render(<App />);
 
-    const { month, year } = getCurrnetDate();
+    const { month, year } = currentDate;
 
     expect(screen.getByText(`${month}/${year}`)).toBeInTheDocument();
   });


### PR DESCRIPTION
Testing with real-time-based date data emerges the unreliable testing dependency.